### PR TITLE
add optional shadda after sunletters

### DIFF
--- a/maps/bgnpcgn-per-Arab-Latn-1958.imp
+++ b/maps/bgnpcgn-per-Arab-Latn-1958.imp
@@ -241,7 +241,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as̄ s̄" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/bgnpcgn-per-Arab-Latn-1958.imp
+++ b/maps/bgnpcgn-per-Arab-Latn-1958.imp
@@ -240,20 +240,20 @@ stage {
     # '\uFE8E' : ''  # ﺎ
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "as̄ s̄" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "az̄ z̄" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "aş ş" # الص
-    sub boundary + "\u0627\u0644\u0636", "aẕ ẕ" # الض
-    sub boundary + "\u0627\u0644\u0637", "aţ ţ" # الط
-    sub boundary + "\u0627\u0644\u0638", "az̧ z̧" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "aş ş" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "aẕ ẕ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aţ ţ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az̧ z̧" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
 
     sub "\u0621", "’" # ء

--- a/maps/bgnpcgn-prs-Arab-Latn-2007.imp
+++ b/maps/bgnpcgn-prs-Arab-Latn-2007.imp
@@ -462,7 +462,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as̄ s̄" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/bgnpcgn-prs-Arab-Latn-2007.imp
+++ b/maps/bgnpcgn-prs-Arab-Latn-2007.imp
@@ -461,20 +461,20 @@ stage {
     # '\uFE8E' : ''  # ﺎ
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "as̄ s̄" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "az̄ z̄" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "aş ş" # الص
-    sub boundary + "\u0627\u0644\u0636", "aẕ ẕ" # الض
-    sub boundary + "\u0627\u0644\u0637", "aţ ţ" # الط
-    sub boundary + "\u0627\u0644\u0638", "az̧ z̧" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "aş ş" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "aẕ ẕ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aţ ţ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az̧ z̧" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
 
     # consonant characters

--- a/maps/bgnpcgn-prs-Arab-Latn-yaghoubi.imp
+++ b/maps/bgnpcgn-prs-Arab-Latn-yaghoubi.imp
@@ -379,20 +379,20 @@ stage {
 
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at̄ t̄" # الت
-    sub boundary + "\u0627\u0644\u062b", "as̄ s̄" # الث
-    sub boundary + "\u0627\u0644\u062f", "aḏ ḏ" # الد
-    sub boundary + "\u0627\u0644\u0630", "az̄ z̄" # الذ
-    sub boundary + "\u0627\u0644\u0631", "aṟ ṟ" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "aš š" # الش
-    sub boundary + "\u0627\u0644\u0635", "as̱ s̱" # الص
-    sub boundary + "\u0627\u0644\u0636", "ad͟z d͟z" # الض
-    sub boundary + "\u0627\u0644\u0637", "aṯ ṯ" # الط
-    sub boundary + "\u0627\u0644\u0638", "aẕ ẕ" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at̄ t̄" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "aḏ ḏ" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "aṟ ṟ" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "aš š" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "as̱ s̱" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "ad͟z d͟z" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aṯ ṯ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "aẕ ẕ" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
     # consonant characters
 

--- a/maps/bgnpcgn-prs-Arab-Latn-yaghoubi.imp
+++ b/maps/bgnpcgn-prs-Arab-Latn-yaghoubi.imp
@@ -380,7 +380,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at̄ t̄" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as̄ s̄" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "aḏ ḏ" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "aṟ ṟ" # الر

--- a/maps/bgnpcgn-pus-Arab-Latn-1968.imp
+++ b/maps/bgnpcgn-pus-Arab-Latn-1968.imp
@@ -249,7 +249,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "ut t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "us̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "us̄ s̄" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ud d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "uz̄ z̄" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ur r" # الر

--- a/maps/bgnpcgn-pus-Arab-Latn-1968.imp
+++ b/maps/bgnpcgn-pus-Arab-Latn-1968.imp
@@ -248,20 +248,20 @@ stage {
     sub "\u0659", "ê"
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "ut t" # الت
-    sub boundary + "\u0627\u0644\u062b", "us̄ s̄" # الث
-    sub boundary + "\u0627\u0644\u062f", "ud d" # الد
-    sub boundary + "\u0627\u0644\u0630", "uz̄ z̄" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ur r" # الر
-    sub boundary + "\u0627\u0644\u0632", "uz z" # الز
-    sub boundary + "\u0627\u0644\u0633", "us s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ush sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "uş ş" # الص
-    sub boundary + "\u0627\u0644\u0636", "uẕ ẕ" # الض
-    sub boundary + "\u0627\u0644\u0637", "uţ ţ" # الط
-    sub boundary + "\u0627\u0644\u0638", "uz̧ z̧" # الظ
-    sub boundary + "\u0627\u0644\u0644", "ul l" # الل
-    sub boundary + "\u0627\u0644\u0646", "un n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "ut t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "us̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ud d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "uz̄ z̄" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ur r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "uz z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "us s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ush sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "uş ş" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "uẕ ẕ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "uţ ţ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "uz̧ z̧" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "ul l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "un n" # الن
 
     sub "\u0626", "êy" # ئ
   }

--- a/maps/bgnpcgn-urd-Arab-Latn-2007.imp
+++ b/maps/bgnpcgn-urd-Arab-Latn-2007.imp
@@ -252,7 +252,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as̄ s̄" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/bgnpcgn-urd-Arab-Latn-2007.imp
+++ b/maps/bgnpcgn-urd-Arab-Latn-2007.imp
@@ -251,20 +251,20 @@ stage {
     # '\uFE8E' : ''  # ﺎ
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "as̄ s̄" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "az̄ z̄" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "aş ş" # الص
-    sub boundary + "\u0627\u0644\u0636", "aẕ ẕ" # الض
-    sub boundary + "\u0627\u0644\u0637", "aţ ţ" # الط
-    sub boundary + "\u0627\u0644\u0638", "az̧ z̧" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "aş ş" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "aẕ ẕ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aţ ţ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az̧ z̧" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
 
     # consonant characters

--- a/maps/iso-ara-Arab-Latn-233-1984.imp
+++ b/maps/iso-ara-Arab-Latn-233-1984.imp
@@ -85,7 +85,7 @@ stage {
     # Sun letters
 
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "aṯ ṯ" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "aṯ ṯ" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "aḏ ḏ" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/iso-ara-Arab-Latn-233-1984.imp
+++ b/maps/iso-ara-Arab-Latn-233-1984.imp
@@ -84,20 +84,20 @@ stage {
 
     # Sun letters
 
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "aṯ ṯ" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "aḏ ḏ" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "aš š" # الش
-    sub boundary + "\u0627\u0644\u0635", "aṣ ṣ" # الص
-    sub boundary + "\u0627\u0644\u0636", "aḍ ḍ" # الض
-    sub boundary + "\u0627\u0644\u0637", "aṭ ṭ" # الط
-    sub boundary + "\u0627\u0644\u0638", "aẓ ẓ" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "aṯ ṯ" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "aḏ ḏ" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "aš š" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "aṣ ṣ" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "aḍ ḍ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aṭ ṭ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "aẓ ẓ" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
     # ta' marboota in iso-233-1984 is all the same `aẗ`
     sub "\u0629", "aẗ" # ة in the middle of the sentence

--- a/maps/iso-prs-Arab-Latn-233-3-1999.imp
+++ b/maps/iso-prs-Arab-Latn-233-3-1999.imp
@@ -245,20 +245,20 @@ stage {
     # '\uFE8E' : ''  # ﺎ
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "as̄ s̄" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "az̄ z̄" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "aş ş" # الص
-    sub boundary + "\u0627\u0644\u0636", "aẕ ẕ" # الض
-    sub boundary + "\u0627\u0644\u0637", "aţ ţ" # الط
-    sub boundary + "\u0627\u0644\u0638", "az̧ z̧" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "aş ş" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "aẕ ẕ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aţ ţ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az̧ z̧" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
     # consonant characters
 

--- a/maps/iso-prs-Arab-Latn-233-3-1999.imp
+++ b/maps/iso-prs-Arab-Latn-233-3-1999.imp
@@ -246,7 +246,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as̄ s̄" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az̄ z̄" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/odni-fas-Arab-Latn-2004.imp
+++ b/maps/odni-fas-Arab-Latn-2004.imp
@@ -141,7 +141,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as s" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as s" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az z" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/odni-fas-Arab-Latn-2004.imp
+++ b/maps/odni-fas-Arab-Latn-2004.imp
@@ -140,20 +140,20 @@ stage {
     # '\uFE8E' : ''  # ﺎ
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "as s" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "az z" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "as s" # الص
-    sub boundary + "\u0627\u0644\u0636", "az z" # الض
-    sub boundary + "\u0627\u0644\u0637", "at t" # الط
-    sub boundary + "\u0627\u0644\u0638", "az z" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as s" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az z" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "as s" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "az z" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "at t" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az z" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
     # Farsi Vowel (Pointing)
     sub "\u0622", "a" # آ alef maddeh

--- a/maps/odni-fas-Arab-Latn-2015.imp
+++ b/maps/odni-fas-Arab-Latn-2015.imp
@@ -258,7 +258,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as s" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as s" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az z" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/odni-fas-Arab-Latn-2015.imp
+++ b/maps/odni-fas-Arab-Latn-2015.imp
@@ -257,20 +257,20 @@ stage {
     # '\uFE8E' : ''  # ﺎ
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "as s" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "az z" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "as s" # الص
-    sub boundary + "\u0627\u0644\u0636", "az z" # الض
-    sub boundary + "\u0627\u0644\u0637", "at t" # الط
-    sub boundary + "\u0627\u0644\u0638", "az z" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as s" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az z" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "as s" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "az z" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "at t" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az z" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
     # Farsi Vowel (Pointing)
     sub "\u0622", "a" # آ alef maddeh

--- a/maps/ses-ara-Arab-Latn-1930.imp
+++ b/maps/ses-ara-Arab-Latn-1930.imp
@@ -129,20 +129,20 @@ stage {
 
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "el-t" # الت
-    sub boundary + "\u0627\u0644\u062b", any(["el-th", "el-t"]) # الث
-    sub boundary + "\u0627\u0644\u062f", "el-d" # الد
-    sub boundary + "\u0627\u0644\u0630", any(["el-dh", "el-z"]) # الذ
-    sub boundary + "\u0627\u0644\u0631", "el-r" # الر
-    sub boundary + "\u0627\u0644\u0632", "el-z" # الز
-    sub boundary + "\u0627\u0644\u0633", any(["el-s", "el-c"]) # الس
-    sub boundary + "\u0627\u0644\u0634", "el-sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "el-ṣ" # الص
-    sub boundary + "\u0627\u0644\u0636", "el-ḍ" # الض
-    sub boundary + "\u0627\u0644\u0637", "el-ṭ" # الط
-    sub boundary + "\u0627\u0644\u0638", any(["el-ẓ", "el-d"]) # الظ
-    sub boundary + "\u0627\u0644\u0644", "el-l" # الل
-    sub boundary + "\u0627\u0644\u0646", "el-n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "el-t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, any(["el-th", "el-t"]) # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "el-d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), any(["el-dh", "el-z"]) # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "el-r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "el-z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), any(["el-s", "el-c"]) # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "el-sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "el-ṣ" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "el-ḍ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "el-ṭ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), any(["el-ẓ", "el-d"]) # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "el-l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "el-n" # الن
 
 
     # shadda

--- a/maps/ses-ara-Arab-Latn-1930.imp
+++ b/maps/ses-ara-Arab-Latn-1930.imp
@@ -130,7 +130,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "el-t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, any(["el-th", "el-t"]) # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), any(["el-th", "el-t"]) # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "el-d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), any(["el-dh", "el-z"]) # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "el-r" # الر

--- a/maps/un-ara-Arab-Latn-1971.imp
+++ b/maps/un-ara-Arab-Latn-1971.imp
@@ -85,10 +85,10 @@ stage {
   parallel {
 
     # sun letters
-    sub boundary + "\u0627\u0644\u062b", "at͟h t͟h" # الث
-    sub boundary + "\u0627\u0644\u0630", "ad͟h d͟h" # الذ
-    sub boundary + "\u0627\u0644\u0634", "as͟h s͟h" # الش
-    sub boundary + "\u0627\u0644\u0638", "az͟h z͟h" # الظ
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "at͟h t͟h" # الث
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "ad͟h d͟h" # الذ
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "as͟h s͟h" # الش
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az͟h z͟h" # الظ
 
     # shadda
     sub "\u062e\u0651", "k͟hk͟h" # خ

--- a/maps/un-ara-Arab-Latn-1971.imp
+++ b/maps/un-ara-Arab-Latn-1971.imp
@@ -85,7 +85,7 @@ stage {
   parallel {
 
     # sun letters
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "at͟h t͟h" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "at͟h t͟h" # الث
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "ad͟h d͟h" # الذ
     sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "as͟h s͟h" # الش
     sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az͟h z͟h" # الظ

--- a/maps/un-ara-Arab-Latn-1972.imp
+++ b/maps/un-ara-Arab-Latn-1972.imp
@@ -107,9 +107,9 @@ stage {
   # CHARACTERS
   parallel {
 
-    sub boundary + "\u0627\u0644\u0635", "aş ş" # الص
-    sub boundary + "\u0627\u0644\u0636", "aḑ ḑ" # الض
-    sub boundary + "\u0627\u0644\u0637", "aţ ţ" # الط
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "aş ş" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "aḑ ḑ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aţ ţ" # الط
 
     sub "\u062d\u0651", "ḩḩ" # ح
     sub "\u0635\u0651", "şş" # ص

--- a/maps/un-ara-Arab-Latn-2017.imp
+++ b/maps/un-ara-Arab-Latn-2017.imp
@@ -141,20 +141,20 @@ stage {
     # (B) Marks doubling of the consonant.
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "ath th" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "adh dh" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "as̱ s̱" # الص
-    sub boundary + "\u0627\u0644\u0636", "aḏ ḏ" # الض
-    sub boundary + "\u0627\u0644\u0637", "aṯ ṯ" # الط
-    sub boundary + "\u0627\u0644\u0638", "ad͟h d͟h" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "ath th" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "adh dh" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "as̱ s̱" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "aḏ ḏ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "aṯ ṯ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "ad͟h d͟h" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
     # TODO: shorten this fragment
     # ta' marboota

--- a/maps/un-ara-Arab-Latn-2017.imp
+++ b/maps/un-ara-Arab-Latn-2017.imp
@@ -142,7 +142,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "ath th" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "ath th" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "adh dh" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر

--- a/maps/un-prs-Arab-Latn-1967.imp
+++ b/maps/un-prs-Arab-Latn-1967.imp
@@ -130,20 +130,20 @@ stage {
 
     # NOTE 1
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "ot t" # الت
-    sub boundary + "\u0627\u0644\u062b", "os̄ s̄" # الث
-    sub boundary + "\u0627\u0644\u062f", "od d" # الد
-    sub boundary + "\u0627\u0644\u0630", "oz̄ z̄" # الذ
-    sub boundary + "\u0627\u0644\u0631", "or r" # الر
-    sub boundary + "\u0627\u0644\u0632", "oz z" # الز
-    sub boundary + "\u0627\u0644\u0633", "os s" # الس
-    sub boundary + "\u0627\u0644\u0634", "osh sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "oş ş" # الص
-    sub boundary + "\u0627\u0644\u0636", "oẕ ẕ" # الض
-    sub boundary + "\u0627\u0644\u0637", "oţ ţ" # الط
-    sub boundary + "\u0627\u0644\u0638", "oz̧ z̧" # الظ
-    sub boundary + "\u0627\u0644\u0644", "ol l" # الل
-    sub boundary + "\u0627\u0644\u0646", "on n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "ot t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "os̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "od d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "oz̄ z̄" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "or r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "oz z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "os s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "osh sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "oş ş" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "oẕ ẕ" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "oţ ţ" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "oz̧ z̧" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "ol l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "on n" # الن
 
     sub "\u0650\u064a\u0651", "īy" # ـِيَّ
     sub "\u0650\u064a", "iy", after: any("\u064e\u064f") # ـِي kasra followed by ي

--- a/maps/un-prs-Arab-Latn-1967.imp
+++ b/maps/un-prs-Arab-Latn-1967.imp
@@ -131,7 +131,7 @@ stage {
     # NOTE 1
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "ot t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "os̄ s̄" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "os̄ s̄" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "od d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "oz̄ z̄" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "or r" # الر

--- a/maps/un-urd-Arab-Latn-1972.imp
+++ b/maps/un-urd-Arab-Latn-1972.imp
@@ -207,20 +207,20 @@ stage {
     # '\uFE8E' : ''  # ﺎ
 
     # Sun letters
-    sub boundary + "\u0627\u0644\u062a", "at t" # الت
-    sub boundary + "\u0627\u0644\u062b", "as s" # الث
-    sub boundary + "\u0627\u0644\u062f", "ad d" # الد
-    sub boundary + "\u0627\u0644\u0630", "az z" # الذ
-    sub boundary + "\u0627\u0644\u0631", "ar r" # الر
-    sub boundary + "\u0627\u0644\u0632", "az z" # الز
-    sub boundary + "\u0627\u0644\u0633", "as s" # الس
-    sub boundary + "\u0627\u0644\u0634", "ash sh" # الش
-    sub boundary + "\u0627\u0644\u0635", "as s" # الص
-    sub boundary + "\u0627\u0644\u0636", "az z" # الض
-    sub boundary + "\u0627\u0644\u0637", "at t" # الط
-    sub boundary + "\u0627\u0644\u0638", "az z" # الظ
-    sub boundary + "\u0627\u0644\u0644", "al l" # الل
-    sub boundary + "\u0627\u0644\u0646", "an n" # الن
+    sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as s" # الث
+    sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
+    sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az z" # الذ
+    sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر
+    sub boundary + "\u0627\u0644\u0632" + maybe("\u0651"), "az z" # الز
+    sub boundary + "\u0627\u0644\u0633" + maybe("\u0651"), "as s" # الس
+    sub boundary + "\u0627\u0644\u0634" + maybe("\u0651"), "ash sh" # الش
+    sub boundary + "\u0627\u0644\u0635" + maybe("\u0651"), "as s" # الص
+    sub boundary + "\u0627\u0644\u0636" + maybe("\u0651"), "az z" # الض
+    sub boundary + "\u0627\u0644\u0637" + maybe("\u0651"), "at t" # الط
+    sub boundary + "\u0627\u0644\u0638" + maybe("\u0651"), "az z" # الظ
+    sub boundary + "\u0627\u0644\u0644" + maybe("\u0651"), "al l" # الل
+    sub boundary + "\u0627\u0644\u0646" + maybe("\u0651"), "an n" # الن
 
 
     # consonant characters

--- a/maps/un-urd-Arab-Latn-1972.imp
+++ b/maps/un-urd-Arab-Latn-1972.imp
@@ -208,7 +208,7 @@ stage {
 
     # Sun letters
     sub boundary + "\u0627\u0644\u062a" + maybe("\u0651"), "at t" # الت
-    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"),, "as s" # الث
+    sub boundary + "\u0627\u0644\u062b" + maybe("\u0651"), "as s" # الث
     sub boundary + "\u0627\u0644\u062f" + maybe("\u0651"), "ad d" # الد
     sub boundary + "\u0627\u0644\u0630" + maybe("\u0651"), "az z" # الذ
     sub boundary + "\u0627\u0644\u0631" + maybe("\u0651"), "ar r" # الر


### PR DESCRIPTION
in arabic, sunletters sometimes come with a shadda on the last letter

example: الرَّجٌل
is having ّ on ر
which is used to make the letter duplicate
so that الرَّجٌل translates to ar rajol
this PR adds it optionally to all the sunletter rules we've