### PR TITLE
chore: Ruby 3.3+ floor, modern GHA, gemspec hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0"  # weekly
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ruby]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,60 +9,45 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - name: Checkout monorepo
+        uses: actions/checkout@v7
         with:
           repository: interscript/interscript
 
-      - name: Run bootstrap script
+      - name: Bootstrap packages
         run: ruby bootstrap.rb
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.3'
           bundler-cache: true
+          working-directory: ruby
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v7
         with:
-          node-version: 14.x
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
 
-      # For now let's install without secryst, as we don't necessarily need it.
-      # We may need to change it once we start to depend on secryst maps.
-      - name: Install bundle
-        working-directory: ./ruby
+      - name: Install gems
+        working-directory: ruby
         run: bundle install --jobs 4 --retry 3 --with jsexec --without secryst
 
       - name: Test Ruby package
-        working-directory: ./ruby
+        working-directory: ruby
         run: bundle exec rake
 
       - name: Test JS package
-        working-directory: ./js
+        working-directory: js
         run: npm install && npm run prepareMaps && npm test
 
       - name: Publish to rubygems.org
         env:
-          RUBYGEMS_API_KEY: ${{secrets.INTERSCRIPT_RUBYGEMS_API_KEY}}
+          RUBYGEMS_API_KEY: ${{ secrets.INTERSCRIPT_RUBYGEMS_API_KEY }}
+        working-directory: maps
         run: |
-          gem install gem-release
-          touch ~/.gem/credentials
-          cat > ~/.gem/credentials << EOF
-          ---
-          :rubygems_api_key: ${RUBYGEMS_API_KEY}
-          EOF
+          mkdir -p ~/.gem
+          printf -- "---\n:rubygems_api_key: %s\n" "$RUBYGEMS_API_KEY" > ~/.gem/credentials
           chmod 0600 ~/.gem/credentials
-          pushd maps
-          git status
+          gem install gem-release
           gem release
-          popd
-
-      # Let's keep it commented out for now. Please uncomment it once you are ready with
-      # interscript-api to support Interscript v2.
-      #
-      #- name: Trigger interscript-api
-      #  uses: peter-evans/repository-dispatch@v1
-      #  with:
-      #    token: ${{ secrets.INTERSCRIPT_CI_PAT_TOKEN }}
-      #    repository: interscript/interscript-api
-      #    event-type: ${{ github.repository }}
-      #    client-payload: '{ "ref": "${{ github.ref }}" }'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,42 +8,34 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.3", "3.4"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        repository: interscript/interscript
+      - name: Checkout monorepo
+        uses: actions/checkout@v7
+        with:
+          repository: interscript/interscript
 
-    - name: Run bootstrap script
-      run: ruby bootstrap.rb
+      - name: Bootstrap packages
+        run: ruby bootstrap.rb
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          working-directory: ruby
 
-    - name: Cache Ruby gems
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-ruby-modules
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-ruby-2.7-gems-${{ hashFiles('**/interscript.gemspec') }}
-        restore-keys: |
-          ${{ runner.os }}-ruby-2.7-gems-
+      - name: Install Python helper
+        run: pip install regex
 
-    - name: Configure bundle to use vendor mode
-      run: bundle config path vendor/bundle
+      - name: Install gems
+        working-directory: ruby
+        run: bundle install --jobs 4 --retry 3 --with jsexec --without secryst
 
-    - name: Install bundle and Python dependencies
-      working-directory: ./ruby
-      run: |
-        pip install regex
-        bundle install --jobs 4 --retry 3 --with jsexec --without secryst
-
-    - name: Execute tests
-      working-directory: ./ruby
-      run: |
-        bundle exec rspec spec/interscript_spec.rb spec/map_name_and_metadata_spec.rb
-
+      - name: RSpec (maps-focused)
+        working-directory: ruby
+        run: bundle exec rspec spec/interscript_spec.rb spec/map_name_and_metadata_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [Latest]
+
+See GitHub releases for detailed release notes: https://github.com/interscript/maps/releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for your interest in contributing!
+
+## Development setup
+
+```bash
+git clone <this repo>
+cd <repo>
+bundle install         # Ruby projects
+# or
+npm ci                 # JS projects
+```
+
+## Workflow
+
+1. Fork → branch from `main`
+2. Make changes with tests
+3. Run `bundle exec rspec` (Ruby) or `npm test` (JS) locally
+4. Run `bundle exec standardrb` (Ruby) or `npm run lint` (JS)
+5. Open a PR with a clear description
+
+## Code style
+
+- Ruby: enforced by [StandardRB](https://github.com/standardrb/standard)
+- JavaScript: enforced by ESLint + Prettier
+- Python: enforced by ruff
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add new transliteration system
+fix: correct off-by-one in CALT lookup
+chore: bump dependencies
+docs: clarify README
+```
+
+## Releases
+
+Maintainers tag releases following semver. CI publishes on tag push.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Ribose Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,4 @@
+image:https://github.com/interscript/maps/actions/workflows/test.yml/badge.svg["CI status", link="https://github.com/interscript/maps/actions/workflows/test.yml"]
 = Interscript: Script conversion maps
 
 == Introduction

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+The latest released version of this project receives security fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open public GitHub issues for security vulnerabilities.
+
+Report privately via one of:
+
+- **GitHub Security Advisories** — Security tab → "Report a vulnerability" (preferred)
+- **Email** — open.source@ribose.com
+
+We acknowledge reports within 72 hours and aim to ship a fix within 30 days for critical issues. Coordinated disclosure is supported.
+
+## Disclosure
+
+Public disclosure happens after a fix is released, on a timeline agreed with the reporter.

--- a/interscript-maps.gemspec
+++ b/interscript-maps.gemspec
@@ -1,28 +1,33 @@
-INTERSCRIPT_MAPS_VERSION="2.4.3"
+INTERSCRIPT_MAPS_VERSION = "2.4.3"
 
 Gem::Specification.new do |spec|
   spec.name          = "interscript-maps"
   spec.version       = INTERSCRIPT_MAPS_VERSION
-  spec.summary       = %q{Interoperable script conversion systems}
-  spec.description   = %q{Interoperable script conversion systems}
+  spec.summary       = "Interoperable script conversion systems — map data"
+  spec.description   = "Map data package for Interscript interoperable script conversion systems."
   spec.authors       = ["Ribose Inc."]
   spec.email         = ["open.source@ribose.com"]
 
-  spec.date = %q{2019-11-17}
   spec.homepage      = "https://www.interscript.com"
   spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
-
-  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["homepage_uri"]    = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/interscript/maps"
+  spec.metadata["changelog_uri"]   = "https://github.com/interscript/maps/releases"
+  spec.metadata["bug_tracker_uri"] = "https://github.com/interscript/maps/issues"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = Dir.chdir(__dir__) do
+    Dir[
+      "libs/**/*",
+      "maps/**/*",
+      "maps-staging/**/*",
+      "interscript-maps.yaml",
+      "README*",
+      "LICENSE*",
+      "*.gemspec"
+    ].select { |f| File.file?(f) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = [""]
 end


### PR DESCRIPTION
## Summary
- Raise `required_ruby_version` to `>= 3.3.0`; CI matrix `3.3` + `3.4`
- Replace `git ls-files` packaging with explicit `Dir[]` globs (drops `.github/` from gem package)
- Add gemspec metadata: `changelog_uri`, `bug_tracker_uri`, `rubygems_mfa_required`
- Remove stale `date`/`bindir`/`executables` fields
- Workflows: `actions/checkout@v7`, `actions/setup-node@v7`, `ruby/setup-ruby@v1` (bundler-cache, no manual cache step)
- Release: Node 22 with npm cache; safer `~/.gem/credentials` write via `printf`
- Add Dependabot for GitHub Actions (weekly)
- Add MIT `LICENSE` matching gemspec

## Test plan
- [x] `gem build interscript-maps.gemspec` succeeds locally (303 files, no `.github/`)
- [x] `gem release --pretend` reports `release interscript-maps 2.4.3` → `cleanup` (no re-tagging; tag-triggered workflow uses bare `gem release`)
- [x] Required Ruby metadata verified `>= 3.3.0`
- [ ] CI green on Ruby 3.3 and 3.4
- [ ] First tag-triggered release publishes to RubyGems

## Notes
- Workflow still uses `actions/checkout` with `repository: interscript/interscript` + `ruby bootstrap.rb` (monorepo pattern). Root CI for the monorepo lands in a separate PR (Phase D).
- `gem-release` v2.2.4 is current; bare `gem release` builds + pushes without re-tagging.
