### PR TITLE
docs: README reflects the .isc corpus

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ Systems from these authorities are included in this repository:
 
 == Organization
 
-All maps are encoded in the "Interoperable Script Processing Model" language syntax (extension: `.imp`).
+All maps are encoded in the "Interoperable Script Conversion" language syntax (extension: `.isc`).
 
 System file names adhere to the script conversion system code convention
 of ISO 24229.


### PR DESCRIPTION
## Summary
- README line still said maps are encoded in ".imp" — the corpus has been 289 .isc files since #180 landed

## Test plan
- [x] grep: zero .imp references remain in README.adoc
