### PR TITLE
ci: parse job clones interscript-ruby main (PR #760 merged)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           ruby-version: "3.4"
       - name: Checkout interscript-ruby
         run: |
-          git clone --depth=1 --branch feat/isc-parser-codemod https://github.com/interscript/interscript-ruby.git ../interscript
+          git clone --depth=1 https://github.com/interscript/interscript-ruby.git ../interscript
       - name: Install parser dependency
         run: gem install parslet
       - name: Parse all .isc files


### PR DESCRIPTION
The feat/isc-parser-codemod pin served while PR #760 was open; the parser line is on main now, so clone the default branch.