### PR TITLE
ci: clone interscript-ts main (port merged)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Checkout interscript-ts
         run: |
-          git clone --depth=1 --branch feat/imf-runtime-ts https://github.com/interscript/interscript-ts.git ../interscript-ts
+          git clone --depth=1 --branch main https://github.com/interscript/interscript-ts.git ../interscript-ts
       - uses: actions/setup-node@v7
         with:
           node-version: "22"


### PR DESCRIPTION
## Summary
- the interscript-ts ISC runtime port landed on main (PR interscript/interscript-ts#35), so the TS parse job clones main instead of the port branch

## Test plan
- [ ] All .isc files parse (TS) green
