### PR TITLE
ci: gem release via RubyGems trusted publishing

### DIFF
--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -1,0 +1,22 @@
+name: gem-release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  rubygems:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+      - run: gem build interscript-maps.gemspec
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary
- restore gem publishing, repo-correct this time: v* tag (or dispatch) -> gem build -> rubygems/release-gem@v1 with id-token:write, the same RubyGems trusted-publishing pattern secryst 1.0.0 used (no API key secret)
- requires a one-time trusted-publisher link on rubygems.org for interscript-maps (repo interscript/maps, workflow gem-release.yml)

## Test plan
- [x] YAML parses
- [ ] after merge + rubygems.org trusted publisher configured: dispatch publishes interscript-maps 2.5.0
