### PR TITLE
ci: workflow filename release.yml (trusted publisher match)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: gem-release
+name: release
 
 on:
   push:


### PR DESCRIPTION
## Summary
- the RubyGems trusted publisher is configured for workflow filename release.yml; this renames gem-release.yml to match so the OIDC publish is accepted

## Test plan
- [x] YAML parses
- [ ] after merge: dispatch publishes interscript-maps 2.5.0
