### PR TITLE
fix: add Gemfile for the release-gem action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec


### PR DESCRIPTION
## Summary
- rubygems/release-gem@v1 pushes via bundler and fails with "Could not locate Gemfile" (exit 10) on a gemspec-only repo; add the minimal standard Gemfile

## Test plan
- [ ] dispatch release.yml after merge publishes interscript-maps 2.5.0
