### PR TITLE
fix: rake in the Gemfile for the release-gem bundler path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rake"


### PR DESCRIPTION
## Summary
- with the Gemfile present, rubygems/release-gem takes the bundler path and invokes rake, which must be in the bundle

## Test plan
- [ ] dispatch after merge publishes interscript-maps 2.5.0
