### PR TITLE
fix: Rakefile with build/release tasks for the release-gem action

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+# Minimal gem tasks for rubygems/release-gem, which runs `rake build` then
+# `rake release`. Hand-rolled because bundler/gem_tasks' release task also
+# creates and pushes a git tag, which conflicts with the existing v* tags
+# this repo cuts for the maps release artifacts.
+task :build do
+  sh "gem build interscript-maps.gemspec"
+end
+
+task release: :build do
+  gem_file = Dir["interscript-maps-*.gem"].sort.last
+  sh "gem push #{gem_file}"
+end


### PR DESCRIPTION
Fourth layer of the rubygems/release-gem onboarding: the action's flow is
bundle install -> rake build -> rake release, so the repo needs those rake
tasks. This adds a minimal Rakefile.

Deliberately hand-rolled instead of `require "bundler/gem_tasks"`: bundler's
release task creates and pushes a vX.Y.Z git tag, and this repo's v* tags are
already cut by the maps artifact release flow (v2.5.0 exists) — bundler would
abort with "Tag v2.5.0 already has been created" before pushing.

- `rake build` — gem build interscript-maps.gemspec
- `rake release` — gem push (uses the OIDC-derived key env the action sets)

Failure ladder so far: no Gemfile (#190) -> rake missing from bundle (#191) ->
no Rakefile (this PR).
