### PR TITLE
fix: build gem into pkg/ for the release-gem await step

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,15 @@
 # Minimal gem tasks for rubygems/release-gem, which runs `rake build` then
-# `rake release`. Hand-rolled because bundler/gem_tasks' release task also
+# `rake release`, then awaits propagation via `pkg/*.gem` — bundler's build
+# convention. Hand-rolled because bundler/gem_tasks' release task also
 # creates and pushes a git tag, which conflicts with the existing v* tags
 # this repo cuts for the maps release artifacts.
 task :build do
   sh "gem build interscript-maps.gemspec"
+  mkdir_p "pkg"
+  mv Dir["interscript-maps-*.gem"].sort.last, "pkg/"
 end
 
 task release: :build do
-  gem_file = Dir["interscript-maps-*.gem"].sort.last
+  gem_file = Dir["pkg/interscript-maps-*.gem"].sort.last
   sh "gem push #{gem_file}"
 end


### PR DESCRIPTION
The 2.5.0 push itself succeeded (gem registered on rubygems.org), but the
action's final propagation-wait step runs `gem exec rubygems-await pkg/*.gem`
— bundler's build convention — and aborted with FormatError on the missing
pkg/ glob because the Rakefile built into the repo root.

This moves the built gem into pkg/ after `gem build`, so future release runs
go green end-to-end. No re-dispatch needed for 2.5.0: the gem is already
published and verified.
